### PR TITLE
Feature/fcliqu 721/build analyze dotnet

### DIFF
--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project_path }}
 
-      - name: Build
-        run: |
-          dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
+      # - name: Build
+      #   run: |
+      #     dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
 
       - name: Test        
         id: tests
@@ -38,7 +38,7 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
-          output=$(test_output.txt)
+          output=$(cat answer.txt)
           echo "body=$output" >> $GITHUB_OUTPUT
           
       - uses: actions/github-script@v8

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         run: |
           pwd
-          cd ./tests/unit/Fintech.Core.Backoffice.Api.Tests
+          cd ./tests/unit/fintech.core.auth.tests
           pwd
           dotnet build -c Release
           dotnet test --configuration Release --results-directory "TestResults" \

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -41,3 +41,5 @@ jobs:
         with:
           name: coverage-report
           path: coveragereport/
+          retention-days: 5
+

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-dotnet@v5 
+        env:
+          NUGET_AUTH_TOKEN: ${{ github.token }}
         with:
           dotnet-version: 8.0.x
+          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
 
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project_path }}

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           pwd
           cd ./tests/unit/Fintech.Core.Backoffice.Api.Tests
+          pwd
+          dotnet build -c Release
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build --no-restore
 

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -33,10 +33,16 @@ jobs:
         run: |
           dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
             --no-build --no-restore 2>&1 | tee test_output.txt
-          
+
+          no_tests_message=""
+          if grep -q "is invalid\. Please use the /help option to check the list of valid arguments" test_output.txt; then
+            echo "Probably no tests were found in tests project"
+            no_tests_message="\n\n **Probably no tests were found in tests project.**"
+          fi
           # multi-line output
           echo "body<<EOF" >> $GITHUB_OUTPUT
           cat test_output.txt >> $GITHUB_OUTPUT
+          echo -e "$no_tests_message" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           
       - uses: actions/github-script@v8

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -31,6 +31,8 @@ jobs:
         id: tests
         continue-on-error: true
         run: |
+          dotnet build -c Release
+
           dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
             --no-build --no-restore 2>&1 | tee test_output.txt
 

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -36,14 +36,8 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
             --no-build --no-restore 2>&1 | tee test_output.txt
 
-          no_tests_message=""
-          if grep -q "is invalid\. Please use the /help option to check the list of valid arguments" test_output.txt; then
-            echo "Probably no tests were found in tests project"
-            no_tests_message="Probably no tests were found in tests project.\n\n"
-          fi
           # multi-line output
           echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$no_tests_message" >> $GITHUB_OUTPUT
           cat test_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -38,13 +38,15 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
+          cat test_output.txt
           
-      - name: Comment test results
-        uses: marocchino/sticky-pull-request-comment@v2
+      - uses: actions/github-script@v8
         with:
-          header: test-results
-          message: |
-            **Test Output**
-            ```
-            $(head -c 6000 test_output.txt)
-            ```
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 Thanks for reporting!'
+            })

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -1,4 +1,4 @@
-name: "Build and Test .NET application"
+name: "Test .NET application"
 
 on:
   workflow_call:
@@ -23,38 +23,21 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project_path }}
 
-      - name: Build
-        run: |
-          dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
-
       - name: Test        
         id: tests
-        continue-on-error: true
         run: |
           dotnet build -c Release
 
           dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
-            --no-build --no-restore 2>&1 | tee test_output.txt
+            --no-build --no-restore
 
-          # multi-line output
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat test_output.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Generate coverage report
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
 
-      - uses: actions/github-script@v8
-        env:
-          BODY: ${{ steps.tests.outputs.body }}
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const body = `**Test Output**
-            \`\`\`
-            ${process.env.BODY}
-            \`\`\``
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body,
-            })
+          name: coverage-report
+          path: coveragereport/

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -31,12 +31,15 @@ jobs:
         id: tests
         continue-on-error: true
         run: |
-          # cd ./tests/unit/fintech.core.auth.tests
+          #cd ./tests/unit/fintech.core.auth.tests
           dotnet build -c Release
-          dotnet test --configuration Release --results-directory "TestResults" \
-            --settings ./tests/unit/fintech.core.auth.tests/cover.runsettings --collect:"XPlat Code Coverage" --no-build \
-            --no-restore 2>&1 | tee test_output.txt
+          # dotnet test --configuration Release --results-directory "TestResults" \
+          #   --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
+          #   --no-restore 2>&1 | tee test_output.txt
 
+          dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
+            --no-build --no-restore 2>&1 | tee test_output.txt
+          
           # multi-line output
           echo "body<<EOF" >> $GITHUB_OUTPUT
           cat test_output.txt >> $GITHUB_OUTPUT

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pwd
           cd ./tests/unit/Fintech.Core.Backoffice.Api.Tests
-          dotnet test ${{ inputs.project_path }} --configuration Release --results-directory "TestResults" \
+          dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build --no-restore
 
 

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -38,8 +38,11 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
-          output=$(cat test_output.txt)
-          echo "body=$output" >> $GITHUB_OUTPUT
+
+          # multi-line output
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          cat test_output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           
       - uses: actions/github-script@v8
         env:

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -7,9 +7,6 @@ on:
         required: true
         type: string
 
-
-
-# proposed to restore, build, test
 jobs:
   configure:
     runs-on: ubuntu-latest
@@ -31,4 +28,9 @@ jobs:
           dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test ${{ inputs.project_path }} --no-restore --verbosity normal
+        run: |
+          dotnet test ${{ inputs.project_path }} --configuration Release --results-directory "TestResults" \
+            --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build --no-restore
+
+
+

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Test
         run: |
+          pwd
+          cd ./tests/unit/Fintech.Core.Backoffice.Api.Tests
           dotnet test ${{ inputs.project_path }} --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build --no-restore
 

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-dotnet@v5 
+      - uses: actions/setup-dotnet@v5
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}
         with:
@@ -27,14 +27,24 @@ jobs:
         run: |
           dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
 
-      - name: Test
+      - name: Test        
+        id: tests
+        continue-on-error: true
         run: |
           pwd
           cd ./tests/unit/fintech.core.auth.tests
           pwd
           dotnet build -c Release
           dotnet test --configuration Release --results-directory "TestResults" \
-            --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build --no-restore
-
-
-
+            --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
+            --no-restore 2>&1 | tee test_output.txt
+          
+      - name: Comment test results
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: test-results
+          message: |
+            **Test Output**
+            ```
+            $(head -c 6000 test_output.txt)
+            ```

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -1,0 +1,32 @@
+name: "Build and Test .NET application"
+
+on:
+  workflow_call:
+    inputs:
+      project_path:
+        required: true
+        type: string
+
+
+
+# proposed to restore, build, test
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v5 
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install dependencies
+        run: dotnet restore ${{ inputs.project_path }}
+
+      - name: Build
+        run: |
+          dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
+          /clp:ErrorsOnly /p:NoWarn=1591
+
+      - name: Test
+        run: dotnet test ${{ inputs.project_path }} --no-restore --verbosity normal

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -23,20 +23,14 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project_path }}
 
-      # - name: Build
-      #   run: |
-      #     dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
+      - name: Build
+        run: |
+          dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
 
       - name: Test        
         id: tests
         continue-on-error: true
         run: |
-          #cd ./tests/unit/fintech.core.auth.tests
-          dotnet build -c Release
-          # dotnet test --configuration Release --results-directory "TestResults" \
-          #   --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
-          #   --no-restore 2>&1 | tee test_output.txt
-
           dotnet test --configuration Release --results-directory "TestResults" --collect:"XPlat Code Coverage" \
             --no-build --no-restore 2>&1 | tee test_output.txt
           

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -37,14 +37,14 @@ jobs:
           no_tests_message=""
           if grep -q "is invalid\. Please use the /help option to check the list of valid arguments" test_output.txt; then
             echo "Probably no tests were found in tests project"
-            no_tests_message="\n\n **Probably no tests were found in tests project.**"
+            no_tests_message="Probably no tests were found in tests project.\n\n"
           fi
           # multi-line output
           echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat test_output.txt >> $GITHUB_OUTPUT
           echo -e "$no_tests_message" >> $GITHUB_OUTPUT
+          cat test_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          
+
       - uses: actions/github-script@v8
         env:
           BODY: ${{ steps.tests.outputs.body }}

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -38,7 +38,7 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
-          output=$(cat answer.txt)
+          output=$(cat test_output.txt)
           echo "body=$output" >> $GITHUB_OUTPUT
           
       - uses: actions/github-script@v8

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -38,15 +38,23 @@ jobs:
           dotnet test --configuration Release --results-directory "TestResults" \
             --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
-          cat test_output.txt
+          output=$(test_output.txt)
+          echo "body=$output" >> $GITHUB_OUTPUT
           
       - uses: actions/github-script@v8
+        env:
+          BODY: ${{ steps.tests.outputs.body }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            const body = `**Test Output**
+            \`\`\`
+            ${process.env.BODY}
+            \`\`\``
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '👋 Thanks for reporting!'
+              body: body,
             })

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -31,12 +31,10 @@ jobs:
         id: tests
         continue-on-error: true
         run: |
-          pwd
-          cd ./tests/unit/fintech.core.auth.tests
-          pwd
+          # cd ./tests/unit/fintech.core.auth.tests
           dotnet build -c Release
           dotnet test --configuration Release --results-directory "TestResults" \
-            --settings cover.runsettings --collect:"XPlat Code Coverage" --no-build \
+            --settings ./tests/unit/fintech.core.auth.tests/cover.runsettings --collect:"XPlat Code Coverage" --no-build \
             --no-restore 2>&1 | tee test_output.txt
 
           # multi-line output

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Build
         run: |
           dotnet build ${{ inputs.project_path }} --configuration Release --no-restore
-          /clp:ErrorsOnly /p:NoWarn=1591
 
       - name: Test
         run: dotnet test ${{ inputs.project_path }} --no-restore --verbosity normal


### PR DESCRIPTION
Add Build and Test .NET application to be called from pull_request, it:

- ads comment under a PR
- has build that can fail
- has (build + test) step

Tested on repos [with tests](https://github.com/dashdevs/fintech.core.auth.core/pull/66) and [without tests](https://github.com/dashdevs/fintech.core.backoffice.api/pull/14)
