### PR TITLE
FCFP-509: Make dotnet_version configurable

### DIFF
--- a/.github/workflows/build-dotnet-app.yml
+++ b/.github/workflows/build-dotnet-app.yml
@@ -19,7 +19,11 @@ on:
       docker_repo_suffix:
         required: false
         type: string
-        default: ''
+        default: ""
+      dotnet_version:
+        required: false
+        type: string
+        default: "8.0.x"
 
 jobs:
   configure:
@@ -62,7 +66,7 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       - name: Build selected architectures
         run: |

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -7,7 +7,10 @@ on:
         required: false
         type: boolean
         default: true
-
+      dotnet_version:
+        required: false
+        type: string
+        default: "8.0.x"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ inputs.dotnet_version }}
       - run: dotnet build -c Release
 
   publish:
@@ -28,7 +31,7 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       - run: |
           dotnet pack --configuration=Release --output artifacts --include-source

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -11,6 +11,7 @@ on:
         required: false
         type: string
         default: "8.0.x"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -6,6 +6,10 @@ on:
       project_path:
         required: true
         type: string
+      dotnet_version:
+        required: false
+        type: string
+        default: "8.0.x"
 
 jobs:
   configure:

--- a/.github/workflows/build-test-dotnet-app.yml
+++ b/.github/workflows/build-test-dotnet-app.yml
@@ -17,13 +17,13 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
 
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project_path }}
 
-      - name: Test        
+      - name: Test
         id: tests
         run: |
           dotnet build -c Release
@@ -42,4 +42,3 @@ jobs:
           name: coverage-report
           path: coveragereport/
           retention-days: 5
-


### PR DESCRIPTION
More builds are migrated to dotnet 10.0.x. It is needed to not only build with 8.0.x version